### PR TITLE
Unit tests for tasks

### DIFF
--- a/tasks/complete_tasks_test.go
+++ b/tasks/complete_tasks_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: ice License 1.0
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ice-blockchain/eskimo/users"
+)
+
+func TestReEvaluateCompletedTasks(t *testing.T) { //nolint:funlen // It's a test function
+	t.Parallel()
+
+	completedTasks := make(users.Enum[Type], 0, len(&AllTypes))
+	for _, taskType := range &AllTypes {
+		completedTasks = append(completedTasks, taskType)
+	}
+	testCases := []struct {
+		p        *progress
+		repo     *repository
+		expected *users.Enum[Type]
+		name     string
+	}{
+		{
+			name: "all tasks are completed",
+			p: &progress{
+				CompletedTasks: &completedTasks,
+			},
+			expected: &completedTasks,
+		},
+		{
+			name: "skip already completed tasks",
+			p: &progress{
+				CompletedTasks: &users.Enum[Type]{ClaimUsernameType, StartMiningType},
+			},
+			repo:     &repository{cfg: &config{}},
+			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType},
+		},
+		{
+			name: "claim username task is completed",
+			p: &progress{
+				UsernameSet: true,
+			},
+			repo:     &repository{cfg: &config{}},
+			expected: &users.Enum[Type]{ClaimUsernameType},
+		},
+		{
+			name: "start mining task is completed",
+			p: &progress{
+				UsernameSet:   true,
+				MiningStarted: true,
+			},
+			repo:     &repository{cfg: &config{}},
+			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType},
+		},
+		{
+			name: "upload profile picture task is completed",
+			p: &progress{
+				UsernameSet:       true,
+				MiningStarted:     true,
+				ProfilePictureSet: true,
+			},
+			repo:     &repository{cfg: &config{}},
+			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType, UploadProfilePictureType},
+		},
+		{
+			name: "follow us on twitter task is completed",
+			p: &progress{
+				UsernameSet:       true,
+				MiningStarted:     true,
+				ProfilePictureSet: true,
+				TwitterUserHandle: "blob",
+			},
+			repo:     &repository{cfg: &config{}},
+			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType, UploadProfilePictureType, FollowUsOnTwitterType},
+		},
+		{
+			name: "join telegram task is completed",
+			p: &progress{
+				UsernameSet:        true,
+				MiningStarted:      true,
+				ProfilePictureSet:  true,
+				TwitterUserHandle:  "blob",
+				TelegramUserHandle: "blob",
+			},
+			repo:     &repository{cfg: &config{RequiredFriendsInvited: 1}},
+			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType, UploadProfilePictureType, FollowUsOnTwitterType, JoinTelegramType},
+		},
+		{
+			name: "invite friends task is completed",
+			p: &progress{
+				UsernameSet:        true,
+				MiningStarted:      true,
+				ProfilePictureSet:  true,
+				TwitterUserHandle:  "blob",
+				TelegramUserHandle: "blob",
+				FriendsInvited:     2,
+			},
+			repo:     &repository{cfg: &config{RequiredFriendsInvited: 1}},
+			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType, UploadProfilePictureType, FollowUsOnTwitterType, JoinTelegramType, InviteFriendsType},
+		},
+		{
+			name: "upload profile picture is completed, but start mining isn't",
+			p: &progress{
+				UsernameSet:       true,
+				ProfilePictureSet: true,
+			},
+			repo:     &repository{cfg: &config{}},
+			expected: &users.Enum[Type]{ClaimUsernameType},
+		},
+		{
+			name:     "no tasks are completed, return nil",
+			p:        &progress{},
+			repo:     &repository{cfg: &config{}},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range testCases { //nolint:gocritic // it's a test, no need for optimization
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.p.reEvaluateCompletedTasks(tt.repo)
+			require.EqualValues(t, tt.expected, got)
+		})
+	}
+}

--- a/tasks/complete_tasks_test.go
+++ b/tasks/complete_tasks_test.go
@@ -17,6 +17,7 @@ func TestReEvaluateCompletedTasks(t *testing.T) { //nolint:funlen // It's a test
 	for _, taskType := range &AllTypes {
 		completedTasks = append(completedTasks, taskType)
 	}
+	bogusUsername := "bogus" //nolint:goconst // .
 	testCases := []struct {
 		p        *progress
 		repo     *repository
@@ -71,7 +72,7 @@ func TestReEvaluateCompletedTasks(t *testing.T) { //nolint:funlen // It's a test
 				UsernameSet:       true,
 				MiningStarted:     true,
 				ProfilePictureSet: true,
-				TwitterUserHandle: "blob",
+				TwitterUserHandle: &bogusUsername,
 			},
 			repo:     &repository{cfg: &config{}},
 			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType, UploadProfilePictureType, FollowUsOnTwitterType},
@@ -82,8 +83,8 @@ func TestReEvaluateCompletedTasks(t *testing.T) { //nolint:funlen // It's a test
 				UsernameSet:        true,
 				MiningStarted:      true,
 				ProfilePictureSet:  true,
-				TwitterUserHandle:  "blob",
-				TelegramUserHandle: "blob",
+				TwitterUserHandle:  &bogusUsername,
+				TelegramUserHandle: &bogusUsername,
 			},
 			repo:     &repository{cfg: &config{RequiredFriendsInvited: 1}},
 			expected: &users.Enum[Type]{ClaimUsernameType, StartMiningType, UploadProfilePictureType, FollowUsOnTwitterType, JoinTelegramType},
@@ -94,8 +95,8 @@ func TestReEvaluateCompletedTasks(t *testing.T) { //nolint:funlen // It's a test
 				UsernameSet:        true,
 				MiningStarted:      true,
 				ProfilePictureSet:  true,
-				TwitterUserHandle:  "blob",
-				TelegramUserHandle: "blob",
+				TwitterUserHandle:  &bogusUsername,
+				TelegramUserHandle: &bogusUsername,
 				FriendsInvited:     2,
 			},
 			repo:     &repository{cfg: &config{RequiredFriendsInvited: 1}},

--- a/tasks/get_tasks_test.go
+++ b/tasks/get_tasks_test.go
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: ice License 1.0
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ice-blockchain/eskimo/users"
+)
+
+func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		p        *progress
+		repo     *repository
+		expected []*Task
+	}{
+		{
+			name: "twitter task is completed",
+			p: &progress{
+				TwitterUserHandle: "blob",
+				CompletedTasks:    &users.Enum[Type]{FollowUsOnTwitterType},
+			},
+			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
+			expected: []*Task{
+				{
+					Data: nil, Type: ClaimUsernameType, Completed: true,
+				},
+				{
+					Data: nil, Type: StartMiningType, Completed: false,
+				},
+				{
+					Data: nil, Type: UploadProfilePictureType, Completed: false,
+				},
+				{
+					Data: &Data{TwitterUserHandle: "blob"}, Type: FollowUsOnTwitterType, Completed: true,
+				},
+				{
+					Data: nil, Type: JoinTelegramType, Completed: false,
+				},
+				{
+					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+				},
+			},
+		},
+		{
+			name: "twitter task is in progress, but not marked as completed",
+			p: &progress{
+				TwitterUserHandle: "blob",
+			},
+			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
+			expected: []*Task{
+				{
+					Data: nil, Type: ClaimUsernameType, Completed: true,
+				},
+				{
+					Data: nil, Type: StartMiningType, Completed: false,
+				},
+				{
+					Data: nil, Type: UploadProfilePictureType, Completed: false,
+				},
+				{
+					Data: &Data{TwitterUserHandle: "blob"}, Type: FollowUsOnTwitterType, Completed: false,
+				},
+				{
+					Data: nil, Type: JoinTelegramType, Completed: false,
+				},
+				{
+					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+				},
+			},
+		},
+		{
+			name: "telegram task is completed",
+			p: &progress{
+				TelegramUserHandle: "blob",
+				CompletedTasks:     &users.Enum[Type]{JoinTelegramType},
+			},
+			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
+			expected: []*Task{
+				{
+					Data: nil, Type: ClaimUsernameType, Completed: true,
+				},
+				{
+					Data: nil, Type: StartMiningType, Completed: false,
+				},
+				{
+					Data: nil, Type: UploadProfilePictureType, Completed: false,
+				},
+				{
+					Data: nil, Type: FollowUsOnTwitterType, Completed: false,
+				},
+				{
+					Data: &Data{TelegramUserHandle: "blob"}, Type: JoinTelegramType, Completed: true,
+				},
+				{
+					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+				},
+			},
+		},
+		{
+			name: "telegram task is in progress, but not marked as completed",
+			p: &progress{
+				TelegramUserHandle: "blob",
+			},
+			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
+			expected: []*Task{
+				{
+					Data: nil, Type: ClaimUsernameType, Completed: true,
+				},
+				{
+					Data: nil, Type: StartMiningType, Completed: false,
+				},
+				{
+					Data: nil, Type: UploadProfilePictureType, Completed: false,
+				},
+				{
+					Data: nil, Type: FollowUsOnTwitterType, Completed: false,
+				},
+				{
+					Data: &Data{TelegramUserHandle: "blob"}, Type: JoinTelegramType, Completed: false,
+				},
+				{
+					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+				},
+			},
+		},
+		{
+			name: "start mining task is pseudocompleted",
+			p: &progress{
+				CompletedTasks:       &users.Enum[Type]{ClaimUsernameType},
+				PseudoCompletedTasks: &users.Enum[Type]{StartMiningType},
+			},
+			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
+			expected: []*Task{
+				{
+					Data: nil, Type: ClaimUsernameType, Completed: true,
+				},
+				{
+					Data: nil, Type: StartMiningType, Completed: true,
+				},
+				{
+					Data: nil, Type: UploadProfilePictureType, Completed: false,
+				},
+				{
+					Data: nil, Type: FollowUsOnTwitterType, Completed: false,
+				},
+				{
+					Data: nil, Type: JoinTelegramType, Completed: false,
+				},
+				{
+					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+				},
+			},
+		},
+		{
+			name: "upload profile picture task is pseudocompleted, but previous one isn't",
+			p: &progress{
+				CompletedTasks:       &users.Enum[Type]{ClaimUsernameType},
+				PseudoCompletedTasks: &users.Enum[Type]{UploadProfilePictureType},
+			},
+			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
+			expected: []*Task{
+				{
+					Data: nil, Type: ClaimUsernameType, Completed: true,
+				},
+				{
+					Data: nil, Type: StartMiningType, Completed: false,
+				},
+				{
+					Data: nil, Type: UploadProfilePictureType, Completed: false,
+				},
+				{
+					Data: nil, Type: FollowUsOnTwitterType, Completed: false,
+				},
+				{
+					Data: nil, Type: JoinTelegramType, Completed: false,
+				},
+				{
+					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases { //nolint:gocritic // it's a test, no need for optimization
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.p.buildTasks(tt.repo)
+			require.EqualValues(t, tt.expected, got)
+		})
+	}
+}
+
+func TestDefaultTasks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default, success", func(t *testing.T) {
+		t.Parallel()
+
+		r := &repository{cfg: &config{RequiredFriendsInvited: 2}}
+		resp := r.defaultTasks()
+		require.EqualValues(t, []*Task{
+			{
+				Data: nil, Type: ClaimUsernameType, Completed: true,
+			},
+			{
+				Data: nil, Type: StartMiningType, Completed: false,
+			},
+			{
+				Data: nil, Type: UploadProfilePictureType, Completed: false,
+			},
+			{
+				Data: nil, Type: FollowUsOnTwitterType, Completed: false,
+			},
+			{
+				Data: nil, Type: JoinTelegramType, Completed: false,
+			},
+			{
+				Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
+			},
+		}, resp)
+	})
+}

--- a/tasks/get_tasks_test.go
+++ b/tasks/get_tasks_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 	t.Parallel()
-
+	bogusUsername := "bogus"
 	testCases := []struct {
 		name     string
 		p        *progress
@@ -22,7 +22,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 		{
 			name: "twitter task is completed",
 			p: &progress{
-				TwitterUserHandle: "blob",
+				TwitterUserHandle: &bogusUsername,
 				CompletedTasks:    &users.Enum[Type]{FollowUsOnTwitterType},
 			},
 			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
@@ -37,7 +37,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 					Data: nil, Type: UploadProfilePictureType, Completed: false,
 				},
 				{
-					Data: &Data{TwitterUserHandle: "blob"}, Type: FollowUsOnTwitterType, Completed: true,
+					Data: &Data{TwitterUserHandle: bogusUsername}, Type: FollowUsOnTwitterType, Completed: true,
 				},
 				{
 					Data: nil, Type: JoinTelegramType, Completed: false,
@@ -50,7 +50,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 		{
 			name: "twitter task is in progress, but not marked as completed",
 			p: &progress{
-				TwitterUserHandle: "blob",
+				TwitterUserHandle: &bogusUsername,
 			},
 			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
 			expected: []*Task{
@@ -64,7 +64,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 					Data: nil, Type: UploadProfilePictureType, Completed: false,
 				},
 				{
-					Data: &Data{TwitterUserHandle: "blob"}, Type: FollowUsOnTwitterType, Completed: false,
+					Data: &Data{TwitterUserHandle: bogusUsername}, Type: FollowUsOnTwitterType, Completed: false,
 				},
 				{
 					Data: nil, Type: JoinTelegramType, Completed: false,
@@ -77,7 +77,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 		{
 			name: "telegram task is completed",
 			p: &progress{
-				TelegramUserHandle: "blob",
+				TelegramUserHandle: &bogusUsername,
 				CompletedTasks:     &users.Enum[Type]{JoinTelegramType},
 			},
 			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
@@ -95,7 +95,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 					Data: nil, Type: FollowUsOnTwitterType, Completed: false,
 				},
 				{
-					Data: &Data{TelegramUserHandle: "blob"}, Type: JoinTelegramType, Completed: true,
+					Data: &Data{TelegramUserHandle: bogusUsername}, Type: JoinTelegramType, Completed: true,
 				},
 				{
 					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,
@@ -105,7 +105,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 		{
 			name: "telegram task is in progress, but not marked as completed",
 			p: &progress{
-				TelegramUserHandle: "blob",
+				TelegramUserHandle: &bogusUsername,
 			},
 			repo: &repository{cfg: &config{RequiredFriendsInvited: 2}},
 			expected: []*Task{
@@ -122,7 +122,7 @@ func TestBuildTasks(t *testing.T) { //nolint:funlen // It's a test function
 					Data: nil, Type: FollowUsOnTwitterType, Completed: false,
 				},
 				{
-					Data: &Data{TelegramUserHandle: "blob"}, Type: JoinTelegramType, Completed: false,
+					Data: &Data{TelegramUserHandle: bogusUsername}, Type: JoinTelegramType, Completed: false,
 				},
 				{
 					Data: &Data{RequiredQuantity: 2}, Type: InviteFriendsType, Completed: false,


### PR DESCRIPTION
In this pr, unit tests for tasks API are added. The functions that aren't interacting with DB or Message Broker.

Following methods/functions are being tested:

```
reEvaluateCompletedTasks
buildTasks
defaultTasks
buildUpdatePseudoCompletedTasksSQL
```