### PR TITLE
fix the issue with duplicated pings from / to  the same users were not calculated and remove slow count(*) call

### DIFF
--- a/levels-and-roles/DDL.sql
+++ b/levels-and-roles/DDL.sql
@@ -27,5 +27,6 @@ CREATE TABLE IF NOT EXISTS agenda_phone_number_hashes (
 CREATE TABLE IF NOT EXISTS pings (
                         user_id    TEXT NOT NULL,
                         pinged_by  TEXT NOT NULL,
-                        PRIMARY KEY(user_id, pinged_by)
+                        last_ping_cooldown_ended_at  TIMESTAMP NOT NULL,
+                        PRIMARY KEY(user_id, pinged_by, last_ping_cooldown_ended_at)
                     );

--- a/levels-and-roles/completed_levels_and_activated_roles.go
+++ b/levels-and-roles/completed_levels_and_activated_roles.go
@@ -5,6 +5,7 @@ package levelsandroles
 import (
 	"context"
 	"fmt"
+	"github.com/ice-blockchain/wintr/time"
 	"math"
 	"strings"
 
@@ -120,8 +121,9 @@ func (s *userPingsSource) Process(ctx context.Context, msg *messagebroker.Messag
 	}
 	type (
 		userPing struct {
-			UserID   string `json:"userId,omitempty" example:"edfd8c02-75e0-4687-9ac2-1ce4723865c4"`
-			PingedBy string `json:"pingedBy,omitempty" example:"edfd8c02-75e0-4687-9ac2-1ce4723865c4"`
+			LastPingCooldownEndedAt *time.Time `json:"lastPingCooldownEndedAt,omitempty" example:"2022-01-03T16:20:52.156534Z"`
+			UserID                  string     `json:"userId,omitempty" example:"edfd8c02-75e0-4687-9ac2-1ce4723865c4"`
+			PingedBy                string     `json:"pingedBy,omitempty" example:"edfd8c02-75e0-4687-9ac2-1ce4723865c4"`
 		}
 	)
 	ping := new(userPing)
@@ -132,22 +134,21 @@ func (s *userPingsSource) Process(ctx context.Context, msg *messagebroker.Messag
 		return nil
 	}
 
-	return errors.Wrapf(s.upsertProgress(ctx, ping.UserID, ping.PingedBy), "failed to upsertProgress for ping:%#v", ping)
+	return errors.Wrapf(s.upsertProgress(ctx, ping.UserID, ping.PingedBy, ping.LastPingCooldownEndedAt), "failed to upsertProgress for ping:%#v", ping)
 }
 
-func (s *userPingsSource) upsertProgress(ctx context.Context, userID, pingedBy string) error {
+func (s *userPingsSource) upsertProgress(ctx context.Context, userID, pingedBy string, lastCooldown *time.Time) error {
 	if pr, err := s.getProgress(ctx, userID); err != nil && !errors.Is(err, storage.ErrRelationNotFound) ||
 		(pr != nil && pr.CompletedLevels != nil &&
 			(len(*pr.CompletedLevels) == len(&AllLevelTypes) ||
 				AreLevelsCompleted(pr.CompletedLevels, Level16Type, Level17Type, Level18Type, Level19Type, Level20Type, Level21Type))) {
 		return errors.Wrapf(err, "failed to getProgress for userID:%v", userID)
 	}
-	sql := `INSERT INTO pings(user_id, pinged_by) VALUES ($1,$2)
-				ON CONFLICT(user_id, pinged_by) DO UPDATE
-				SET pinged_by = $2`
+	sql := `INSERT INTO pings(user_id, pinged_by,last_ping_cooldown_ended_at) VALUES ($1,$2, $3) ON CONFLICT (user_id, pinged_by, last_ping_cooldown_ended_at) DO NOTHING`
 	params := []any{
 		userID,
 		pingedBy,
+		lastCooldown.Time,
 	}
 	if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
 		return errors.Wrapf(err, "failed to insert pings, params:%#v", params...)

--- a/levels-and-roles/completed_levels_and_activated_roles.go
+++ b/levels-and-roles/completed_levels_and_activated_roles.go
@@ -5,7 +5,6 @@ package levelsandroles
 import (
 	"context"
 	"fmt"
-	"github.com/ice-blockchain/wintr/time"
 	"math"
 	"strings"
 
@@ -18,6 +17,7 @@ import (
 	messagebroker "github.com/ice-blockchain/wintr/connectors/message_broker"
 	storage "github.com/ice-blockchain/wintr/connectors/storage/v2"
 	"github.com/ice-blockchain/wintr/log"
+	"github.com/ice-blockchain/wintr/time"
 )
 
 func (s *miningSessionSource) Process(ctx context.Context, msg *messagebroker.Message) error {
@@ -144,7 +144,8 @@ func (s *userPingsSource) upsertProgress(ctx context.Context, userID, pingedBy s
 				AreLevelsCompleted(pr.CompletedLevels, Level16Type, Level17Type, Level18Type, Level19Type, Level20Type, Level21Type))) {
 		return errors.Wrapf(err, "failed to getProgress for userID:%v", userID)
 	}
-	sql := `INSERT INTO pings(user_id, pinged_by,last_ping_cooldown_ended_at) VALUES ($1,$2, $3) ON CONFLICT (user_id, pinged_by, last_ping_cooldown_ended_at) DO NOTHING`
+	sql := `INSERT INTO pings(user_id, pinged_by,last_ping_cooldown_ended_at) VALUES ($1,$2, $3)
+            ON CONFLICT (user_id, pinged_by, last_ping_cooldown_ended_at) DO NOTHING`
 	params := []any{
 		userID,
 		pingedBy,


### PR DESCRIPTION
For now when user sends more than one ping request to another request, all those pings are calculated as one ping in levels progress.

This PR fixes the issue by adding new column in pings table to store ping time in that column. As a result multiple events from the same users will have different time and will be calculated independently.