### PR TITLE
Remove count(*) calls from referrals calculations

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -123,6 +123,10 @@ badges: &badges
         partitions: 10
         replicationFactor: 1
         retention: 1000h
+      - name: referral-counts
+        partitions: 10
+        replicationFactor: 1
+        retention: 1000h
       ### The next topics are not owned by this service, but are needed to be created for the local/test environment.
       - name: users-table
         partitions: 10
@@ -147,6 +151,7 @@ badges: &badges
       - name: completed-levels
       - name: balances-table
       - name: global-table
+      - name: referral-counts
 badges_test:
   <<: *badges
   messageBroker:
@@ -181,6 +186,10 @@ tasks: &tasks
         partitions: 10
         replicationFactor: 1
         retention: 1000h
+      - name: referral-counts
+        partitions: 10
+        replicationFactor: 1
+        retention: 1000h
       ### The next topics are not owned by this service, but are needed to be created for the local/test environment.
       - name: users-table
         partitions: 10
@@ -198,6 +207,7 @@ tasks: &tasks
       - name: try-complete-tasks-commands
       - name: users-table
       - name: mining-sessions-table
+      - name: referral-counts
     producingTopics:
       - name: add-balance-commands
 tasks_test:
@@ -263,6 +273,10 @@ levels-and-roles: &levels-and-roles
         partitions: 10
         replicationFactor: 1
         retention: 1000h
+      - name: referral-counts
+        partitions: 10
+        replicationFactor: 1
+        retention: 1000h
       ### The next topics are not owned by this service, but are needed to be created for the local/test environment.
       - name: users-table
         partitions: 10
@@ -291,6 +305,7 @@ levels-and-roles: &levels-and-roles
       - name: started-days-off
       - name: completed-tasks
       - name: user-pings
+      - name: referral-counts
 levels-and-roles_test:
   <<: *levels-and-roles
   messageBroker:

--- a/badges/.testdata/application.yaml
+++ b/badges/.testdata/application.yaml
@@ -101,6 +101,10 @@ badges: &badges
         partitions: 10
         replicationFactor: 1
         retention: 1000h
+      - name: referral-counts
+        partitions: 10
+        replicationFactor: 1
+        retention: 1000h
       ### The next topics are not owned by this service, but are needed to be created for the local/test environment.
       - name: users-table
         partitions: 10
@@ -125,6 +129,7 @@ badges: &badges
       - name: completed-levels
       - name: balances-table
       - name: global-table
+      - name: referral-counts
 badges_test:
   <<: *badges
   messageBroker:

--- a/badges/achieve_badges.go
+++ b/badges/achieve_badges.go
@@ -4,6 +4,7 @@ package badges
 
 import (
 	"context"
+	"github.com/ice-blockchain/santa/tasks"
 	"sort"
 
 	"github.com/goccy/go-json"
@@ -229,34 +230,25 @@ func (s *userTableSource) upsertProgress(ctx context.Context, us *users.UserSnap
 
 	return multierror.Append( //nolint:wrapcheck // Not needed.
 		errors.Wrapf(err, "failed to upsert progress for %#v", us),
-		errors.Wrapf(s.updateFriendsInvited(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
+		errors.Wrapf(s.insertReferrals(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
 		errors.Wrapf(s.sendTryAchieveBadgesCommandMessage(ctx, us.ID), "failed to sendTryAchieveBadgesCommandMessage for userID:%v", us.ID),
 	).ErrorOrNil()
 }
 
 //nolint:gocognit // .
-func (s *userTableSource) updateFriendsInvited(ctx context.Context, us *users.UserSnapshot) error {
+func (s *userTableSource) insertReferrals(ctx context.Context, us *users.UserSnapshot) error {
 	if ctx.Err() != nil || us.User == nil || us.User.ReferredBy == "" || us.User.ReferredBy == us.User.ID || (us.Before != nil && us.Before.ID != "" && us.User.ReferredBy == us.Before.ReferredBy) { //nolint:lll,revive // .
 		return errors.Wrap(ctx.Err(), "context failed")
 	}
-	sql := `INSERT INTO referrals(user_id,referred_by)
-					VALUES($1, $2)
-				ON CONFLICT(user_id)
-				DO UPDATE
-					SET referred_by = EXCLUDED.referred_by
-				WHERE COALESCE(referrals.referred_by, '') != COALESCE(EXCLUDED.referred_by, '')`
-	if _, err := storage.Exec(ctx, s.db, sql, us.User.ID, us.User.ReferredBy); err != nil {
-		return errors.Wrapf(err, "failed to insert referrals, userID:%v, referredBy:%v", us.User.ID, us.User.ReferredBy)
-	}
-
-	sql = `INSERT INTO badge_progress(user_id, friends_invited)
-					VALUES($1, (SELECT COUNT(*) FROM referrals WHERE referred_by = $1))
-				ON CONFLICT(user_id)
-				DO UPDATE
-					SET friends_invited = EXCLUDED.friends_invited
-				WHERE COALESCE(badge_progress.friends_invited, 0) != COALESCE(EXCLUDED.friends_invited, 0)`
-	if _, err := storage.Exec(ctx, s.db, sql, us.User.ReferredBy); err != nil {
-		return errors.Wrapf(err, "failed to set insert badge_progress friends_invited for referredBy:%v", us.User.ReferredBy)
+	err := storage.DoInTransaction(ctx, s.db, func(conn storage.QueryExecer) error {
+		sql := `INSERT INTO referrals(user_id,referred_by) VALUES($1, $2)`
+		if _, err := storage.Exec(ctx, s.db, sql, us.User.ID, us.User.ReferredBy); err != nil {
+			return errors.Wrapf(err, "failed to insert referrals, userID:%v, referredBy:%v", us.User.ID, us.User.ReferredBy)
+		}
+		return errors.Wrapf(s.sendReferralsCountUpdate(ctx, us.User.ReferredBy), "failed to send referral counts update")
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to execute transaction")
 	}
 
 	return errors.Wrapf(s.sendTryAchieveBadgesCommandMessage(ctx, us.User.ReferredBy),
@@ -271,6 +263,56 @@ func (s *userTableSource) deleteProgress(ctx context.Context, us *users.UserSnap
 	_, err := storage.Exec(ctx, s.db, sql, us.Before.ID)
 
 	return errors.Wrapf(err, "failed to delete badge_progress for:%#v", us)
+}
+
+func (r *repository) sendReferralsCountUpdate(ctx context.Context, userID string) error {
+	pr, err := r.getProgress(ctx, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get progress while sending referrals count update")
+	}
+	refCount := &tasks.ReferralsCount{
+		UserID:    userID,
+		Referrals: pr.FriendsInvited + 1,
+	}
+	valueBytes, err := json.MarshalContext(ctx, refCount)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal %#v", refCount)
+	}
+	msg := &messagebroker.Message{
+		Headers: map[string]string{"producer": "santa"},
+		Key:     userID,
+		Topic:   r.cfg.MessageBroker.Topics[3].Name,
+		Value:   valueBytes,
+	}
+	responder := make(chan error, 1)
+	defer close(responder)
+	r.mb.SendMessage(ctx, msg, responder)
+
+	return errors.Wrapf(<-responder, "failed to send `%v` message to broker", msg.Topic)
+}
+
+func (r *referralCountsSource) Process(ctx context.Context, msg *messagebroker.Message) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "unexpected deadline while processing message")
+	}
+	if len(msg.Value) == 0 {
+		return nil
+	}
+	refCount := new(tasks.ReferralsCount)
+	if err := json.UnmarshalContext(ctx, msg.Value, refCount); err != nil {
+		return errors.Wrapf(err, "cannot unmarshal %v into %#v", string(msg.Value), refCount)
+	}
+
+	return errors.Wrapf(r.updateFriendsInvited(ctx, refCount), "failed to update")
+}
+func (r *referralCountsSource) updateFriendsInvited(ctx context.Context, refCount *tasks.ReferralsCount) error {
+	sql := `INSERT INTO badge_progress(user_id, friends_invited) VALUES ($1, $2)
+		   		ON CONFLICT(user_id) DO UPDATE  
+		   			SET friends_invited = $2
+		   		WHERE COALESCE(badge_progress.friends_invited, 0) != COALESCE(EXCLUDED.friends_invited, 0)`
+	_, err := storage.Exec(ctx, r.db, sql, refCount.UserID, refCount.Referrals)
+
+	return errors.Wrapf(err, "failed to set badge_progress.friends_invited, params:%#v", refCount)
 }
 
 func (s *completedLevelsSource) Process(ctx context.Context, msg *messagebroker.Message) error {

--- a/badges/badges.go
+++ b/badges/badges.go
@@ -47,6 +47,7 @@ func StartProcessor(ctx context.Context, cancel context.CancelFunc) Processor {
 		&completedLevelsSource{processor: prc},
 		&balancesTableSource{processor: prc},
 		&globalTableSource{processor: prc},
+		&referralCountsSource{processor: prc},
 	)
 	prc.shutdown = closeAll(mbConsumer, prc.mb, prc.db)
 

--- a/badges/contract.go
+++ b/badges/contract.go
@@ -310,6 +310,11 @@ type (
 	userTableSource struct {
 		*processor
 	}
+
+	referralCountsSource struct {
+		*processor
+	}
+
 	completedLevelsSource struct {
 		*processor
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ice-blockchain/eskimo v1.109.1-0.20230511103205-9e1e7c3d9d92
 	github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb
-	github.com/ice-blockchain/wintr v1.109.0
+	github.com/ice-blockchain/wintr v1.111.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.2
 	github.com/swaggo/swag v1.16.1
-	github.com/testcontainers/testcontainers-go v0.19.0
+	github.com/testcontainers/testcontainers-go v0.20.1
 )
 
 require (
@@ -33,11 +33,11 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
-	github.com/containerd/containerd v1.7.0 // indirect
+	github.com/containerd/containerd v1.7.1 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/docker v23.0.5+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
+	github.com/docker/docker v23.0.6+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,7 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.3+incompatible h1:+HS4XO73J41FpA260ztGujJ+0WibrA2TPJEnWNSyGNE=
 github.com/docker/docker v20.10.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -265,8 +265,8 @@ github.com/ice-blockchain/eskimo v1.109.1-0.20230511103205-9e1e7c3d9d92 h1:IDsKZ
 github.com/ice-blockchain/eskimo v1.109.1-0.20230511103205-9e1e7c3d9d92/go.mod h1:n/hV5aulMd/8snFyLIgqESjR2Z/BHha0p+lVkbf2P8Q=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb h1:8TnFP3mc7O+tc44kv2e0/TpZKnEVUaKH+UstwfBwRkk=
 github.com/ice-blockchain/go-tarantool-client v0.0.0-20230327200757-4fc71fa3f7bb/go.mod h1:ZsQU7i3mxhgBBu43Oev7WPFbIjP4TniN/b1UPNGbrq8=
-github.com/ice-blockchain/wintr v1.109.0 h1:j7oB7tVmXxNwfLLSxAbp93Lp3JtbyU7Ey9P3R1TRP7U=
-github.com/ice-blockchain/wintr v1.109.0/go.mod h1:X5fdqdlV9TIyP0TGEmjGrOfhWsM9YPJpwPQ6R04/wOs=
+github.com/ice-blockchain/wintr v1.111.0 h1:Zn2QHcFc6Epihff/T2yVxmJXqidJIxf3h0YF5XBn+ps=
+github.com/ice-blockchain/wintr v1.111.0/go.mod h1:W5LKKLumtureMCvjWdg5clEdB2gIhhG0BeAb8ok1THs=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/imroc/req/v3 v3.34.0 h1:ChzOrBy397f+mvLTGT0yai9FeODsZnLQU7EnRvVlhiY=
@@ -523,7 +523,6 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=

--- a/levels-and-roles/.testdata/application.yaml
+++ b/levels-and-roles/.testdata/application.yaml
@@ -58,6 +58,10 @@ levels-and-roles: &levels-and-roles
         partitions: 10
         replicationFactor: 1
         retention: 1000h
+      - name: referral-counts
+        partitions: 10
+        replicationFactor: 1
+        retention: 1000h
       ### The next topics are not owned by this service, but are needed to be created for the local/test environment.
       - name: users-table
         partitions: 10
@@ -86,6 +90,7 @@ levels-and-roles: &levels-and-roles
       - name: started-days-off
       - name: completed-tasks
       - name: user-pings
+      - name: referral-counts
 levels-and-roles_test:
   <<: *levels-and-roles
   messageBroker:

--- a/levels-and-roles/completed_levels_and_activated_roles.go
+++ b/levels-and-roles/completed_levels_and_activated_roles.go
@@ -226,7 +226,7 @@ func (s *userTableSource) upsertProgress(ctx context.Context, us *users.UserSnap
 	return multierror.Append( //nolint:wrapcheck // Not needed.
 		errors.Wrapf(err, "failed to upsert progress for %#v", insertTuple),
 		errors.Wrapf(s.updateAgendaContactsJoined(ctx, us), "failed to updateAgendaContactsJoined for user:%#v", us),
-		errors.Wrapf(s.insertNewReferrals(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
+		errors.Wrapf(s.insertNewReferrals(ctx, us), "failed to insertNewReferrals for user:%#v", us),
 		errors.Wrapf(s.insertAgendaPhoneNumberHashes(ctx, us), "failed to insertAgendaPhoneNumberHashes for user:%#v", us),
 		errors.Wrapf(s.sendTryCompleteLevelsCommandMessage(ctx, us.ID), "failed to sendTryCompleteLevelsCommandMessage for userID:%v", us.ID),
 	).ErrorOrNil()
@@ -275,24 +275,31 @@ func (s *userTableSource) insertNewReferrals(ctx context.Context, us *users.User
 	if ctx.Err() != nil || us.User == nil || us.User.ReferredBy == "" || us.User.ReferredBy == us.User.ID || (us.Before != nil && us.Before.ID != "" && us.User.ReferredBy == us.Before.ReferredBy) { //nolint:lll,revive // .
 		return errors.Wrap(ctx.Err(), "context failed")
 	}
-	err := storage.DoInTransaction(ctx, s.db, func(conn storage.QueryExecer) error {
-		sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)`
-		params := []any{
-			us.User.ID,
-			us.User.ReferredBy,
-		}
-		if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
-			return errors.Wrapf(err, "failed to REPLACE INTO referrals, params:%#v", params...)
+	sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)`
+	params := []any{
+		us.User.ID,
+		us.User.ReferredBy,
+	}
+	if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
+		if storage.IsErr(err, storage.ErrDuplicate) {
+			return nil
 		}
 
-		return errors.Wrapf(s.sendReferralsCountUpdate(ctx, us.User.ReferredBy), "failed to send referral counts update")
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to execute transaction")
+		return errors.Wrapf(err, "failed to insert referrals, params:%#v", params...)
+	}
+	if sErr := s.sendReferralsCountUpdate(ctx, us.User.ReferredBy); sErr != nil {
+		sErr = errors.Wrapf(sErr, "failed to send referral counts update")
+		sql = `DELETE FROM referrals WHERE user_id = $1 AND referred_by = $2`
+		if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
+			return multierror.Append(sErr, //nolint:wrapcheck // Not needed.
+				errors.Wrapf(err, "failed to delete referrals, params:%#v", params...)).ErrorOrNil()
+		}
+
+		return sErr
 	}
 
 	return errors.Wrapf(s.sendTryCompleteLevelsCommandMessage(ctx, us.User.ReferredBy),
-		"failed to sendTryCompleteLevelsCommandMessage, userID:%v,referredBy:%v", us.User.ID, us.User.ReferredBy)
+		"failed to sendTryCompleteLevelsCommandMessage, params:%#v", params...)
 }
 
 func (r *repository) sendReferralsCountUpdate(ctx context.Context, userID string) error {
@@ -335,6 +342,7 @@ func (r *referralCountsSource) Process(ctx context.Context, msg *messagebroker.M
 
 	return errors.Wrapf(r.updateFriendsInvited(ctx, refCount), "failed to update")
 }
+
 func (r *referralCountsSource) updateFriendsInvited(ctx context.Context, refCount *tasks.ReferralsCount) error {
 	sql := `INSERT INTO levels_and_roles_progress(user_id, friends_invited) VALUES ($1, $2)
 		   		ON CONFLICT(user_id) DO UPDATE  

--- a/levels-and-roles/completed_levels_and_activated_roles.go
+++ b/levels-and-roles/completed_levels_and_activated_roles.go
@@ -226,7 +226,7 @@ func (s *userTableSource) upsertProgress(ctx context.Context, us *users.UserSnap
 	return multierror.Append( //nolint:wrapcheck // Not needed.
 		errors.Wrapf(err, "failed to upsert progress for %#v", insertTuple),
 		errors.Wrapf(s.updateAgendaContactsJoined(ctx, us), "failed to updateAgendaContactsJoined for user:%#v", us),
-		errors.Wrapf(s.updateFriendsInvited(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
+		errors.Wrapf(s.insertNewReferrals(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
 		errors.Wrapf(s.insertAgendaPhoneNumberHashes(ctx, us), "failed to insertAgendaPhoneNumberHashes for user:%#v", us),
 		errors.Wrapf(s.sendTryCompleteLevelsCommandMessage(ctx, us.ID), "failed to sendTryCompleteLevelsCommandMessage for userID:%v", us.ID),
 	).ErrorOrNil()
@@ -271,29 +271,77 @@ func (s *userTableSource) updateAgendaContactsJoined(ctx context.Context, us *us
 }
 
 //nolint:gocognit // .
-func (s *userTableSource) updateFriendsInvited(ctx context.Context, us *users.UserSnapshot) error {
+func (s *userTableSource) insertNewReferrals(ctx context.Context, us *users.UserSnapshot) error {
 	if ctx.Err() != nil || us.User == nil || us.User.ReferredBy == "" || us.User.ReferredBy == us.User.ID || (us.Before != nil && us.Before.ID != "" && us.User.ReferredBy == us.Before.ReferredBy) { //nolint:lll,revive // .
 		return errors.Wrap(ctx.Err(), "context failed")
 	}
-	sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)
- 				ON CONFLICT(user_id) DO UPDATE
- 				SET referred_by = $2`
-	params := []any{
-		us.User.ID,
-		us.User.ReferredBy,
-	}
-	if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
-		return errors.Wrapf(err, "failed to REPLACE INTO referrals, params:%#v", params...)
-	}
-	sql = `INSERT INTO levels_and_roles_progress(user_id, friends_invited) VALUES ($1, (SELECT COUNT(*) FROM referrals WHERE referred_by = $1))
-		   		ON CONFLICT(user_id) DO UPDATE  
-		   		SET friends_invited = EXCLUDED.friends_invited`
-	if _, err := storage.Exec(ctx, s.db, sql, us.User.ReferredBy); err != nil {
-		return errors.Wrapf(err, "failed to set task_progress.friends_invited, params:%#v", params...)
+	err := storage.DoInTransaction(ctx, s.db, func(conn storage.QueryExecer) error {
+		sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)`
+		params := []any{
+			us.User.ID,
+			us.User.ReferredBy,
+		}
+		if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
+			return errors.Wrapf(err, "failed to REPLACE INTO referrals, params:%#v", params...)
+		}
+
+		return errors.Wrapf(s.sendReferralsCountUpdate(ctx, us.User.ReferredBy), "failed to send referral counts update")
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to execute transaction")
 	}
 
 	return errors.Wrapf(s.sendTryCompleteLevelsCommandMessage(ctx, us.User.ReferredBy),
 		"failed to sendTryCompleteLevelsCommandMessage, userID:%v,referredBy:%v", us.User.ID, us.User.ReferredBy)
+}
+
+func (r *repository) sendReferralsCountUpdate(ctx context.Context, userID string) error {
+	pr, err := r.getProgress(ctx, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get progress while sending referrals count update")
+	}
+	refCount := &tasks.ReferralsCount{
+		UserID:    userID,
+		Referrals: pr.FriendsInvited + 1,
+	}
+	valueBytes, err := json.MarshalContext(ctx, refCount)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal %#v", refCount)
+	}
+	msg := &messagebroker.Message{
+		Headers: map[string]string{"producer": "santa"},
+		Key:     userID,
+		Topic:   r.cfg.MessageBroker.Topics[4].Name,
+		Value:   valueBytes,
+	}
+	responder := make(chan error, 1)
+	defer close(responder)
+	r.mb.SendMessage(ctx, msg, responder)
+
+	return errors.Wrapf(<-responder, "failed to send `%v` message to broker", msg.Topic)
+}
+
+func (r *referralCountsSource) Process(ctx context.Context, msg *messagebroker.Message) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "unexpected deadline while processing message")
+	}
+	if len(msg.Value) == 0 {
+		return nil
+	}
+	refCount := new(tasks.ReferralsCount)
+	if err := json.UnmarshalContext(ctx, msg.Value, refCount); err != nil {
+		return errors.Wrapf(err, "cannot unmarshal %v into %#v", string(msg.Value), refCount)
+	}
+
+	return errors.Wrapf(r.updateFriendsInvited(ctx, refCount), "failed to update")
+}
+func (r *referralCountsSource) updateFriendsInvited(ctx context.Context, refCount *tasks.ReferralsCount) error {
+	sql := `INSERT INTO levels_and_roles_progress(user_id, friends_invited) VALUES ($1, $2)
+		   		ON CONFLICT(user_id) DO UPDATE  
+		   		SET friends_invited = $2`
+	_, err := storage.Exec(ctx, r.db, sql, refCount.UserID, refCount.Referrals)
+
+	return errors.Wrapf(err, "failed to set levels_and_roles_progress.friends_invited, params:%#v", refCount)
 }
 
 func (s *userTableSource) insertAgendaPhoneNumberHashes(ctx context.Context, us *users.UserSnapshot) error { //nolint:funlen // .

--- a/levels-and-roles/contract.go
+++ b/levels-and-roles/contract.go
@@ -152,6 +152,9 @@ type (
 	userTableSource struct {
 		*processor
 	}
+	referralCountsSource struct {
+		*processor
+	}
 	miningSessionSource struct {
 		*processor
 	}

--- a/levels-and-roles/levels_and_roles.go
+++ b/levels-and-roles/levels_and_roles.go
@@ -49,6 +49,7 @@ func StartProcessor(ctx context.Context, cancel context.CancelFunc) Processor {
 		&startedDaysOffSource{miningSessionSource: mss},
 		&completedTasksSource{processor: prc},
 		&userPingsSource{processor: prc},
+		&referralCountsSource{processor: prc},
 	)
 	prc.shutdown = closeAll(mbConsumer, prc.mb, prc.db)
 

--- a/tasks/.testdata/application.yaml
+++ b/tasks/.testdata/application.yaml
@@ -29,6 +29,10 @@ tasks: &tasks
         partitions: 10
         replicationFactor: 1
         retention: 1000h
+      - name: referral-counts
+        partitions: 10
+        replicationFactor: 1
+        retention: 1000h
       ### The next topics are not owned by this service, but are needed to be created for the local/test environment.
       - name: users-table
         partitions: 10
@@ -46,6 +50,7 @@ tasks: &tasks
       - name: try-complete-tasks-commands
       - name: users-table
       - name: mining-sessions-table
+      - name: referral-counts
     producingTopics:
       - name: add-balance-commands
 tasks_test:

--- a/tasks/complete_tasks.go
+++ b/tasks/complete_tasks.go
@@ -413,32 +413,41 @@ func (s *userTableSource) upsertProgress(ctx context.Context, us *users.UserSnap
 
 	return multierror.Append( //nolint:wrapcheck // Not needed.
 		errors.Wrapf(err, "failed to upsert progress for %#v", us),
-		errors.Wrapf(s.updateFriendsInvited(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
+		errors.Wrapf(s.insertReferrals(ctx, us), "failed to updateFriendsInvited for user:%#v", us),
 		errors.Wrapf(s.sendTryCompleteTasksCommandMessage(ctx, us.ID), "failed to sendTryCompleteTasksCommandMessage for userID:%v", us.ID),
 	).ErrorOrNil()
 }
 
 //nolint:gocognit // .
-func (s *userTableSource) updateFriendsInvited(ctx context.Context, us *users.UserSnapshot) error {
+func (s *userTableSource) insertReferrals(ctx context.Context, us *users.UserSnapshot) error {
 	if ctx.Err() != nil || us.User == nil || us.User.ReferredBy == "" || us.User.ReferredBy == us.User.ID || (us.Before != nil && us.Before.ID != "" && us.User.ReferredBy == us.Before.ReferredBy) { //nolint:lll,revive // .
 		return errors.Wrap(ctx.Err(), "context failed")
 	}
-	err := storage.DoInTransaction(ctx, s.db, func(conn storage.QueryExecer) error {
-		sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)`
-		params := []any{
-			us.User.ID,
-			us.User.ReferredBy,
-		}
-		if _, err := storage.Exec(ctx, conn, sql, params...); err != nil {
-			return errors.Wrapf(err, "failed to REPLACE INTO referrals, params:%#v", params...)
-		}
-		return errors.Wrapf(s.sendReferralsCountUpdate(ctx, us.User.ReferredBy), "failed to send referrals counts update")
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to execute transaction")
+	sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)`
+	params := []any{
+		us.User.ID,
+		us.User.ReferredBy,
 	}
+	if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
+		if storage.IsErr(err, storage.ErrDuplicate) {
+			return nil
+		}
+
+		return errors.Wrapf(err, "failed to insert referrals, params:%#v", params...)
+	}
+	if sErr := s.sendReferralsCountUpdate(ctx, us.User.ReferredBy); sErr != nil {
+		sErr = errors.Wrapf(sErr, "failed to send referrals counts update")
+		sql = `DELETE FROM referrals WHERE user_id = $1 AND referred_by = $2`
+		if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
+			return multierror.Append(sErr, //nolint:wrapcheck // Not needed.
+				errors.Wrapf(err, "failed to delete referrals, pararms:%#v", params...)).ErrorOrNil()
+		}
+
+		return sErr
+	}
+
 	return errors.Wrapf(s.sendTryCompleteTasksCommandMessage(ctx, us.User.ReferredBy),
-		"failed to sendTryCompleteTasksCommandMessage, userID:%v,referredBy:%v", us.User.ID, us.User.ReferredBy)
+		"failed to sendTryCompleteTasksCommandMessage, params:%#v", params...)
 }
 
 func (r *referralCountsSource) Process(ctx context.Context, msg *messagebroker.Message) error {
@@ -455,6 +464,7 @@ func (r *referralCountsSource) Process(ctx context.Context, msg *messagebroker.M
 
 	return errors.Wrapf(r.updateFriendsInvited(ctx, refCount), "failed to update")
 }
+
 func (r *referralCountsSource) updateFriendsInvited(ctx context.Context, refCount *ReferralsCount) error {
 	sql := `INSERT INTO task_progress(user_id, friends_invited) VALUES ($1, $2)
 		   ON CONFLICT(user_id) DO UPDATE  

--- a/tasks/complete_tasks.go
+++ b/tasks/complete_tasks.go
@@ -423,25 +423,71 @@ func (s *userTableSource) updateFriendsInvited(ctx context.Context, us *users.Us
 	if ctx.Err() != nil || us.User == nil || us.User.ReferredBy == "" || us.User.ReferredBy == us.User.ID || (us.Before != nil && us.Before.ID != "" && us.User.ReferredBy == us.Before.ReferredBy) { //nolint:lll,revive // .
 		return errors.Wrap(ctx.Err(), "context failed")
 	}
-	sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)
-				ON CONFLICT(user_id) DO UPDATE
-				SET referred_by = $2`
-	params := []any{
-		us.User.ID,
-		us.User.ReferredBy,
+	err := storage.DoInTransaction(ctx, s.db, func(conn storage.QueryExecer) error {
+		sql := `INSERT INTO referrals(user_id,referred_by) VALUES ($1,$2)`
+		params := []any{
+			us.User.ID,
+			us.User.ReferredBy,
+		}
+		if _, err := storage.Exec(ctx, conn, sql, params...); err != nil {
+			return errors.Wrapf(err, "failed to REPLACE INTO referrals, params:%#v", params...)
+		}
+		return errors.Wrapf(s.sendReferralsCountUpdate(ctx, us.User.ReferredBy), "failed to send referrals counts update")
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to execute transaction")
 	}
-	if _, err := storage.Exec(ctx, s.db, sql, params...); err != nil {
-		return errors.Wrapf(err, "failed to REPLACE INTO referrals, params:%#v", params...)
-	}
-	sql = `INSERT INTO task_progress(user_id, friends_invited) VALUES ($1, (SELECT COUNT(*) FROM referrals WHERE referred_by = $1))
-		   ON CONFLICT(user_id) DO UPDATE  
-		   		SET friends_invited = EXCLUDED.friends_invited`
-	if _, err := storage.Exec(ctx, s.db, sql, us.User.ReferredBy); err != nil {
-		return errors.Wrapf(err, "failed to set task_progress.friends_invited, params:%#v", params...)
-	}
-
 	return errors.Wrapf(s.sendTryCompleteTasksCommandMessage(ctx, us.User.ReferredBy),
 		"failed to sendTryCompleteTasksCommandMessage, userID:%v,referredBy:%v", us.User.ID, us.User.ReferredBy)
+}
+
+func (r *referralCountsSource) Process(ctx context.Context, msg *messagebroker.Message) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "unexpected deadline while processing message")
+	}
+	if len(msg.Value) == 0 {
+		return nil
+	}
+	refCount := new(ReferralsCount)
+	if err := json.UnmarshalContext(ctx, msg.Value, refCount); err != nil {
+		return errors.Wrapf(err, "cannot unmarshal %v into %#v", string(msg.Value), refCount)
+	}
+
+	return errors.Wrapf(r.updateFriendsInvited(ctx, refCount), "failed to update")
+}
+func (r *referralCountsSource) updateFriendsInvited(ctx context.Context, refCount *ReferralsCount) error {
+	sql := `INSERT INTO task_progress(user_id, friends_invited) VALUES ($1, $2)
+		   ON CONFLICT(user_id) DO UPDATE  
+		   		SET friends_invited = $2`
+	_, err := storage.Exec(ctx, r.db, sql, refCount.UserID, refCount.Referrals)
+
+	return errors.Wrapf(err, "failed to set task_progress.friends_invited, params:%#v", refCount)
+}
+
+func (r *repository) sendReferralsCountUpdate(ctx context.Context, userID string) error {
+	pr, err := r.getProgress(ctx, userID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get progress while sending referrals count update")
+	}
+	refCount := &ReferralsCount{
+		UserID:    userID,
+		Referrals: pr.FriendsInvited + 1,
+	}
+	valueBytes, err := json.MarshalContext(ctx, refCount)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal %#v", refCount)
+	}
+	msg := &messagebroker.Message{
+		Headers: map[string]string{"producer": "santa"},
+		Key:     userID,
+		Topic:   r.cfg.MessageBroker.Topics[3].Name,
+		Value:   valueBytes,
+	}
+	responder := make(chan error, 1)
+	defer close(responder)
+	r.mb.SendMessage(ctx, msg, responder)
+
+	return errors.Wrapf(<-responder, "failed to send `%v` message to broker", msg.Topic)
 }
 
 func (s *userTableSource) deleteProgress(ctx context.Context, us *users.UserSnapshot) error {

--- a/tasks/contract.go
+++ b/tasks/contract.go
@@ -82,6 +82,10 @@ type (
 		Repository
 		CheckHealth(context.Context) error
 	}
+	ReferralsCount struct {
+		UserID    string `json:"userId,omitempty" example:"edfd8c02-75e0-4687-9ac2-1ce4723865c4"`
+		Referrals uint64
+	}
 )
 
 // Private API.
@@ -116,6 +120,10 @@ type (
 		*processor
 	}
 	userTableSource struct {
+		*processor
+	}
+
+	referralCountsSource struct {
 		*processor
 	}
 	repository struct {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -45,6 +45,7 @@ func StartProcessor(ctx context.Context, cancel context.CancelFunc) Processor {
 		&tryCompleteTasksCommandSource{processor: prc},
 		&userTableSource{processor: prc},
 		&miningSessionSource{processor: prc},
+		&referralCountsSource{processor: prc},
 	)
 	prc.shutdown = closeAll(mbConsumer, prc.mb, prc.db)
 


### PR DESCRIPTION
This PR removes count(*) calls from calculating referrals count.
Now it works via new topic `referral-counts`, first package who processes UserSnapshot with new referral inserts data into referrals table, and sends message to new topic for the other packages. Other packages get "duplicate" error when trying to insert data into referrals, and receives that message from new topic to update value.

The same fix is applied for pings calculations in levels_and_roles by #7 